### PR TITLE
Fix reference to /api/shopify/auth/enable_cookies in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ export default async function shopifyAuthCallback(req, res) {
 }
 ```
 
-#### /api/shopify/auth/enable-cookies
+#### /api/shopify/auth/enable_cookies
 
 ```js
 import shopify from "../../../../lib/shopify"; // lib is on the root dir


### PR DESCRIPTION
Fixes incorrect reference to `/api/shopify/auth/enable-cookies` when it should be `/api/shopify/auth/enable_cookies`